### PR TITLE
2025.2/back end/configuracion/get mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Envía mensajes SMS si se presionan botones o se detecta voz.
 `config.py` \
 Carga las claves desde .env para que el resto de módulos las usen.
 
+`configuracionEstructura.py`
+
+Devuelve la configuración actual del recordatorio que debe utilizar el dispositivo ESP32 para reproducir el mensaje y activar la alarma.
+
 ## Componentes funcionales del sistema
 
 ### Uso del modelo de lenguaje (LLM)

--- a/configuracionEstructura.py
+++ b/configuracionEstructura.py
@@ -1,0 +1,16 @@
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+@app.route('/configuracion', methods=['GET'])
+def obtener_configuracion_mock():
+    configuracion_mock = {
+        "hora": "18:00",
+        "medicamento": "aspirina",
+        "mensaje": "Abuela, son las seis. Hora de tomar aspirina.",
+        "audio_filename": "aspirina_1800.mp3"
+    }
+    return jsonify(configuracion_mock)
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
Devuelve la configuración actual del recordatorio que debe utilizar el dispositivo ESP32 para reproducir el mensaje y activar la alarma basado en un evento mock 